### PR TITLE
Do nothing when there is no user with groups

### DIFF
--- a/action.php
+++ b/action.php
@@ -6,6 +6,8 @@
  * @author  Andreas Gohr <gohr@cosmocode.de>
  */
 
+use dokuwiki\Extension\ActionPlugin;
+
 // must be run within Dokuwiki
 if (!defined('DOKU_INC')) die();
 
@@ -13,32 +15,33 @@ if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
 if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
 if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 
-require_once DOKU_PLUGIN.'action.php';
+class action_plugin_grouphome extends ActionPlugin
+{
 
-class action_plugin_grouphome extends DokuWiki_Action_Plugin {
-
-    public function register(Doku_Event_Handler $controller) {
-
-       $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handle_hook');
-
+    public function register(Doku_Event_Handler $controller)
+    {
+       $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'handleHook');
     }
 
-    public function handle_hook(Doku_Event $event, $param) {
+    public function handleHook(Doku_Event $event)
+    {
         global $INFO;
         global $ID;
         global $conf;
 
-        if($ID != $conf['start']) return;
-        if(act_clean($event->data) != 'show') return;
+        if (!isset($INFO['userinfo']['grps'])) return;
+
+        if ($ID != $conf['start']) return;
+        if( act_clean($event->data) != 'show') return;
 
         $grps = (array) $INFO['userinfo']['grps'];
-        if(!count($grps)) return;
+        if (!count($grps)) return;
 
         $pages = $this->getConf('grouppages');
 
-        foreach($grps as $grp){
+        foreach ($grps as $grp) {
             $page = cleanID(sprintf($pages,$grp));
-            if(page_exists($page)){
+            if (page_exists($page)) {
                 send_redirect(wl($page,'',true));
             }
         }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   grouphome
 author Andreas Gohr
 email  gohr@cosmocode.de
-date   2018-05-09
+date   2023-01-11
 name   grouphome plugin
 desc   Redirect logged in users from the start page to their primary group's homepage
 url    http://www.dokuwiki.org/plugin:grouphome


### PR DESCRIPTION
Eliminates a warning in PHP 8. Plus some whitespace formatting.